### PR TITLE
Accept ERP POT files without gettext header

### DIFF
--- a/transifex/resources/formats/pofile.py
+++ b/transifex/resources/formats/pofile.py
@@ -86,6 +86,17 @@ class GettextHandler(SimpleCompilerFactory, Handler):
     HandlerParseError = PoParseError
     HandlerCompileError = PoCompileError
 
+    default_metadata = {
+        'Content-Type': 'text/plain; charset=UTF-8',
+        'Content-Transfer-Encoding': '8bit',
+    }
+
+    def _ensure_default_metadata(self, po):
+        """Accept ERP-generated PO/POT files without a gettext header."""
+        for metadata, value in self.default_metadata.items():
+            if metadata not in po.metadata:
+                po.metadata[metadata] = value
+
     def _check_content(self, content):
         try:
             po = polib.pofile(content)
@@ -101,6 +112,8 @@ class GettextHandler(SimpleCompilerFactory, Handler):
         # Msgfmt check
         if settings.FILECHECKS['POFILE_MSGFMT']:
             msgfmt_check(content, self.is_pot)
+
+        self._ensure_default_metadata(po)
 
         # Check required header fields
         required_metadata = ['Content-Type', 'Content-Transfer-Encoding']

--- a/transifex/resources/tests/lib/pofile/main.py
+++ b/transifex/resources/tests/lib/pofile/main.py
@@ -393,6 +393,24 @@ class TestPoFile(FormatsBaseTestCase):
 class TestPoFileHeaders(FormatsBaseTestCase):
     """Test PO File library support for PO file headers."""
 
+    ERP_POT_WITHOUT_HEADER = u'''#: model:ir.model.fields,field_description:test.field_name
+msgid "Field name"
+msgstr ""
+
+#: model:ir.model.fields,field_description:test.field_other
+msgid "Other field"
+msgstr ""
+'''
+
+    POT_WITH_PARTIAL_HEADER = u'''msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=ISO-8859-1\\n"
+
+#: model:ir.model.fields,field_description:test.field_name
+msgid "Field name"
+msgstr ""
+'''
+
     def _load_pot(self):
         test_file = os.path.join(TEST_FILES_PATH, 'test.pot')
         # First empty our resource
@@ -424,6 +442,32 @@ class TestPoFileHeaders(FormatsBaseTestCase):
         self.assertTrue("Portuguese (Brazil)" in pofile)
         self.assertFalse(self.urls['team'] in pofile)
         self.assertTrue(self.team.mainlist in pofile)
+
+    def test_pot_without_gettext_header_is_valid(self):
+        """ERP exports may omit the gettext metadata header."""
+        handler = POTHandler(content=self.ERP_POT_WITHOUT_HEADER)
+        handler.is_content_valid()
+        self.assertEqual(
+            handler._po.metadata['Content-Type'],
+            'text/plain; charset=UTF-8'
+        )
+        self.assertEqual(
+            handler._po.metadata['Content-Transfer-Encoding'],
+            '8bit'
+        )
+
+    def test_pot_with_partial_gettext_header_is_valid(self):
+        """Missing gettext metadata is completed without replacing values."""
+        handler = POTHandler(content=self.POT_WITH_PARTIAL_HEADER)
+        handler.is_content_valid()
+        self.assertEqual(
+            handler._po.metadata['Content-Type'],
+            'text/plain; charset=ISO-8859-1'
+        )
+        self.assertEqual(
+            handler._po.metadata['Content-Transfer-Encoding'],
+            '8bit'
+        )
 
 
 class TestPoFileCopyright(FormatsBaseTestCase):


### PR DESCRIPTION
## Summary

- Accept ERP-generated PO/POT files that omit the gettext metadata header by filling safe defaults in the gettext handler.
- Preserve existing metadata values when only part of the header is present.
- Add regression tests for POT content without a header and with a partial header.

Refs #3
TASK-91093

## Tests

- `python -m py_compile transifex/resources/formats/pofile.py transifex/resources/tests/lib/pofile/main.py`
- `git diff --check`

Could not run the Django test case in this host: the available Python 2 environment has Django 1.11.29, while this project requires Django 1.3.1, so `python manage.py test resources.tests.lib.pofile.main.TestPoFileHeaders --verbosity=2` fails importing `django.core.management.execute_manager` before loading tests.
