### PR TITLE
Sort language resources before pagination

### DIFF
--- a/transifex/teams/tests/views.py
+++ b/transifex/teams/tests/views.py
@@ -3,6 +3,7 @@ from django.test.client import Client
 from django.contrib.auth.models import User
 
 from languages.models import Language
+from transifex.resources.models import Resource, RLStats, SourceEntity
 from transifex.teams.models import TeamRequest, TeamAccessRequest
 from transifex.teams.models import Team
 from txcommon.tests import base, utils
@@ -21,6 +22,52 @@ class TestTeams(base.BaseTestCase):
         url = reverse('team_detail', args=[self.project.slug, self.language.code])
         resp = self.client['registered'].get(url)
         self.assertContains(resp, '(Brazil)', status_code=200)
+
+    def _create_resource_with_stats(self, slug, name, total, translated):
+        resource = Resource.objects.create(
+            slug=slug, name=name, project=self.project, i18n_type='PO')
+        for i in range(total):
+            SourceEntity.objects.create(
+                string='%s string %s' % (slug, i), context='Context%s' % i,
+                occurrences='Occurrences%s' % i, resource=resource)
+        resource.update_total_entities()
+
+        stats = RLStats.objects.get(resource=resource, language=self.language)
+        stats.translated = translated
+        stats.untranslated = total - translated
+        stats._calculate_perc()
+        stats.save(update=False)
+        return resource
+
+    def test_team_details_sorts_completion_globally_before_paginating(self):
+        for i in range(16):
+            self._create_resource_with_stats(
+                'full-%02d' % i, 'Full %02d' % i, 10, 10)
+        zero_resource = self._create_resource_with_stats(
+            'aaa-zero', 'AAA Zero', 10, 0)
+        RLStats.objects.filter(resource=zero_resource,
+            language=self.language).delete()
+
+        url = reverse('team_detail', args=[self.project.slug, self.language.code])
+        resp = self.client['registered'].get(url)
+
+        self.assertContains(resp, 'AAA Zero', status_code=200)
+        first_page = list(resp.context['statslist'])
+        first_page_slugs = [stat.resource.slug for stat in first_page]
+        self.assertIn('aaa-zero', first_page_slugs)
+
+    def test_team_details_sorts_resources_by_name_on_server(self):
+        self._create_resource_with_stats('zzz-resource', 'ZZZ Resource', 10, 0)
+        self._create_resource_with_stats('aaa-resource', 'AAA Resource', 100, 100)
+
+        url = reverse('team_detail', args=[self.project.slug, self.language.code])
+        resp = self.client['registered'].get(url, {'sort': 'name', 'dir': 'asc'})
+
+        self.assertContains(resp, 'AAA Resource', status_code=200)
+        first_page = list(resp.context['statslist'])
+        first_page_slugs = [stat.resource.slug for stat in first_page]
+        self.assertTrue(first_page_slugs.index('aaa-resource') <
+            first_page_slugs.index('zzz-resource'))
 
     def test_create_team(self):
         """Test a successful team creation."""

--- a/transifex/teams/views.py
+++ b/transifex/teams/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 from django.db import transaction
@@ -31,6 +32,53 @@ from transifex.txcommon import notifications as txnotification
 
 from transifex.txcommon.decorators import one_perm_required_or_403, access_off
 from transifex.txcommon.log import logger
+
+
+LANGUAGE_DETAIL_SORTS = ('completion', 'name', 'last_update', 'priority')
+
+
+def _sort_language_stats(statslist, sort, direction):
+    """Sort language resource stats before template pagination."""
+    reverse = direction == 'desc'
+
+    def resource_name(stat):
+        return (stat.resource.project.name or '', stat.resource.name or '',
+            stat.resource.slug or '')
+
+    def priority_level(stat):
+        try:
+            priority = stat.resource.priority
+        except ObjectDoesNotExist:
+            return 0
+        return priority.level if priority else 0
+
+    def stat_key(stat):
+        if sort == 'last_update':
+            return (stat.last_update is not None, stat.last_update)
+        elif sort == 'priority':
+            return priority_level(stat)
+        return stat.translated_perc
+
+    statslist = sorted(statslist, key=resource_name)
+    if sort == 'name':
+        return sorted(statslist, key=resource_name, reverse=reverse)
+
+    return sorted(statslist, key=stat_key, reverse=reverse)
+
+
+def _language_detail_sort_urls(request, active_sort, active_direction):
+    sort_urls = {}
+    for sort in LANGUAGE_DETAIL_SORTS:
+        params = request.GET.copy()
+        if 'page' in params:
+            del params['page']
+        params['sort'] = sort
+        if sort == active_sort:
+            params['dir'] = active_direction == 'asc' and 'desc' or 'asc'
+        else:
+            params['dir'] = sort == 'last_update' and 'desc' or 'asc'
+        sort_urls[sort] = '?%s' % params.urlencode()
+    return sort_urls
 
 
 def team_off(request, project, *args, **kwargs):
@@ -195,6 +243,12 @@ def team_detail(request, project_slug, language_code):
     project = get_object_or_404(Project.objects.select_related(), slug=project_slug)
     language = Language.objects.by_code_or_alias_or_404(language_code)
     team = Team.objects.get_or_none(project, language.code)
+    sort = request.GET.get('sort', 'completion')
+    direction = request.GET.get('dir', 'asc')
+    if sort not in LANGUAGE_DETAIL_SORTS:
+        sort = 'completion'
+    if direction not in ('asc', 'desc'):
+        direction = 'asc'
 
     filter_form = ProjectsFilterForm(project, request.GET)
 
@@ -244,6 +298,7 @@ def team_detail(request, project_slug, language_code):
             untranslated=resource.total_entities,
         )
         statslist.append(rl)
+    statslist = _sort_language_stats(statslist, sort, direction)
 
     return render_to_response("teams/team_detail.html", {
         "project": project,
@@ -255,6 +310,10 @@ def team_detail(request, project_slug, language_code):
         "filter_form": filter_form,
         "total_entries": total_entries,
         "coordinators": coordinators,
+        "language_stats_sort": sort,
+        "language_stats_direction": direction,
+        "language_stats_sort_urls": _language_detail_sort_urls(request, sort,
+            direction),
     }, context_instance=RequestContext(request))
 
 @access_off(team_off)
@@ -770,4 +829,3 @@ def team_request_deny(request, project_slug, language_code):
 
     return HttpResponseRedirect(reverse("project_detail",
                                         args=[project_slug,]))
-

--- a/transifex/templates/teams/team_detail.html
+++ b/transifex/templates/teams/team_detail.html
@@ -158,13 +158,13 @@ $(function(){
 {% endif %}
 
   {% if statslist %}
-  <table class="stats-table tablesorter langdetail">
+  <table class="stats-table langdetail">
   <thead>
     <tr>
-      <th class="onlyarrow tableobject"></th>
-      <th class="onlyarrow tablecompletion"></th>
-      <th class="onlyarrow tablelastupd"></th>
-      <th class="onlyarrow priority_level"></th>
+      <th class="onlyarrow tableobject"><a href="{{ language_stats_sort_urls.name }}" title="{% trans "Sort by resource name" %}">&nbsp;</a></th>
+      <th class="onlyarrow tablecompletion"><a href="{{ language_stats_sort_urls.completion }}" title="{% trans "Sort by translation progress" %}">&nbsp;</a></th>
+      <th class="onlyarrow tablelastupd"><a href="{{ language_stats_sort_urls.last_update }}" title="{% trans "Sort by last update" %}">&nbsp;</a></th>
+      <th class="onlyarrow priority_level"><a href="{{ language_stats_sort_urls.priority }}" title="{% trans "Sort by priority" %}">&nbsp;</a></th>
     </tr>
   </thead>
   <tbody id="stat-row-container">


### PR DESCRIPTION
## Summary

- TASK-91106
- Sort language detail resources server-side before template pagination.
- Include synthetic 0% RLStats entries in the same global ordering as persisted stats.
- Replace client-side tablesorter handling for this infinite-scroll table with server-side sort links.
- Add regression coverage for more than 15 resources and resources without RLStats.

## Validation

- Python 2.7.18 py_compile for transifex/teams/views.py and transifex/teams/tests/views.py
- git diff --check

Could not run the Django test case locally: the available Python 2 virtualenv has a newer Django where django.core.management.execute_manager is already removed, while this project pins Django 1.3.1.