### PR TITLE
Add ERP-stable PO compilation profile

### DIFF
--- a/transifex/projects/forms.py
+++ b/transifex/projects/forms.py
@@ -35,7 +35,7 @@ class ProjectForm(forms.ModelForm):
         fields = (
             'name', 'slug', 'description', 'trans_instructions', 'tags',
             'long_description', 'maintainers', 'private', 'homepage', 'feed',
-            'bug_tracker', 'source_language', 'logo',
+            'bug_tracker', 'source_language', 'logo', 'compilation_profile',
         )
 
     def __init__(self, *args, **kwargs):

--- a/transifex/projects/migrations/0011_add_compilation_profile.py
+++ b/transifex/projects/migrations/0011_add_compilation_profile.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.add_column(
+            'projects_project',
+            'compilation_profile',
+            self.gf('django.db.models.fields.CharField')(
+                max_length=32, null=True, blank=True
+            ),
+            keep_default=False
+        )
+
+    def backwards(self, orm):
+        db.delete_column('projects_project', 'compilation_profile')
+
+    models = {
+        'projects.project': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Project'},
+            'compilation_profile': (
+                'django.db.models.fields.CharField', [],
+                {'max_length': '32', 'null': 'True', 'blank': 'True'}
+            ),
+            'id': (
+                'django.db.models.fields.AutoField', [],
+                {'primary_key': 'True'}
+            ),
+        },
+    }
+
+    complete_apps = ['projects']

--- a/transifex/projects/models.py
+++ b/transifex/projects/models.py
@@ -153,6 +153,10 @@ class Project(models.Model):
     """
     A project is a group of translatable resources.
     """
+    COMPILATION_PROFILE_CHOICES = (
+        ('', _('Default')),
+        ('erp_stable', _('ERP stable PO/POT output')),
+    )
 
     private = models.BooleanField(default=False, verbose_name=_('Private'),
         help_text=_('A private project is visible only by you and your team. '
@@ -194,6 +198,10 @@ class Project(models.Model):
     logo = ThumbnailerImageField(_('Logo'), blank=True, null=True,
         upload_to=upload_to_mugshot, resize_source=PROJECT_LOGO_SETTINGS,
         help_text=_('A logo image displayed for the project.'))
+    compilation_profile = models.CharField(
+        _('Compilation profile'), max_length=32, blank=True, null=True,
+        choices=COMPILATION_PROFILE_CHOICES,
+        help_text=_('Default output profile for downloaded translation files.'))
 
     # Relations
     maintainers = models.ManyToManyField(User, verbose_name=_('Maintainers'),

--- a/transifex/resources/api/__init__.py
+++ b/transifex/resources/api/__init__.py
@@ -479,7 +479,10 @@ class TranslationHandler(BaseHandler):
 
         translation = Translation.get_object("get", request, r, language)
         try:
-            res = translation.get(pseudo_type=pseudo_type, mode=mode)
+            profile = request.GET.get('profile', None)
+            res = translation.get(
+                pseudo_type=pseudo_type, mode=mode, profile=profile
+            )
         except BadRequestError, e:
             return BAD_REQUEST(unicode(e))
         except FormatsBackendError, e:
@@ -655,12 +658,13 @@ class Translation(object):
             self.resource, self.language, user=self.request.user
         )
 
-    def get(self, pseudo_type, mode=None):
+    def get(self, pseudo_type, mode=None, profile=None):
         """Get a translation.
 
         Args:
             pseudo_type: The pseudo_type to use, if any.
             mode: The mode of compilation, if any.
+            profile: Optional output profile, if any.
         """
         raise NotImplementedError
 
@@ -735,7 +739,7 @@ class FileTranslation(Translation):
         )
         return response
 
-    def get(self, pseudo_type, mode=None):
+    def get(self, pseudo_type, mode=None, profile=None):
         """
         Return the requested translation as a file.
 
@@ -747,7 +751,9 @@ class FileTranslation(Translation):
         """
         try:
             fb = FormatsBackend(self.resource, self.language)
-            return fb.compile_translation(pseudo_type, mode=mode)
+            return fb.compile_translation(
+                pseudo_type, mode=mode, profile=profile
+            )
         except Exception, e:
             logger.error(unicode(e), exc_info=True)
             raise BadRequestError("Error compiling the translation file: %s" %e )
@@ -812,7 +818,8 @@ class StringTranslation(Translation):
     Handle requests for translation as strings.
     """
 
-    def get(self, start=None, end=None, pseudo_type=None, mode=None):
+    def get(self, start=None, end=None, pseudo_type=None, mode=None,
+            profile=None):
         """
         Return the requested translation in a json string.
 
@@ -823,6 +830,7 @@ class StringTranslation(Translation):
             end: End for pagination.
             pseudo_type: The pseudo_type requested.
             mode: The mode for the compilation.
+            profile: Optional output profile, if any.
         Returns:
             A dict with the translation(s).
         Raises:
@@ -830,7 +838,9 @@ class StringTranslation(Translation):
         """
         try:
             fb = FormatsBackend(self.resource, self.language)
-            template = fb.compile_translation(pseudo_type, mode=mode)
+            template = fb.compile_translation(
+                pseudo_type, mode=mode, profile=profile
+            )
         except Exception, e:
             logger.error(unicode(e), exc_info=True)
             raise BadRequestError(

--- a/transifex/resources/backends.py
+++ b/transifex/resources/backends.py
@@ -183,7 +183,7 @@ class FormatsBackend(object):
         except FormatError, e:
             raise FormatsBackendError(unicode(e))
 
-    def compile_translation(self, pseudo_type=None, mode=None):
+    def compile_translation(self, pseudo_type=None, mode=None, profile=None):
         """Compile the translation for a resource in a specified language.
 
         There is some extra care for PO/POT resources. If there is no
@@ -197,6 +197,8 @@ class FormatsBackend(object):
         Args:
             pseudo_type: The pseudo_type (if any).
             mode: The mode for compiling this translation.
+            profile: Optional output profile for format-specific
+                normalization.
         Returns:
             The compiled template.
         """
@@ -207,7 +209,9 @@ class FormatsBackend(object):
         )
         handler.bind_resource(self.resource)
         handler.set_language(self.language)
-        content = handler.compile(pseudo=pseudo_type, mode=mode)
+        content = handler.compile(
+            pseudo=pseudo_type, mode=mode, profile=profile
+        )
         return content if isinstance(content, basestring) else ''
 
 

--- a/transifex/resources/backends.py
+++ b/transifex/resources/backends.py
@@ -164,6 +164,13 @@ class FormatsBackend(object):
             resource, language, filename=filename
         )
 
+    def _effective_compilation_profile(self, profile):
+        """Return the explicit profile or the project's default profile."""
+        if profile:
+            return profile
+        project = getattr(self.resource, 'project', None)
+        return getattr(project, 'compilation_profile', None)
+
     def _import_content(self, handler, content, is_source):
         """Import content to the database.
 
@@ -210,7 +217,8 @@ class FormatsBackend(object):
         handler.bind_resource(self.resource)
         handler.set_language(self.language)
         content = handler.compile(
-            pseudo=pseudo_type, mode=mode, profile=profile
+            pseudo=pseudo_type, mode=mode,
+            profile=self._effective_compilation_profile(profile)
         )
         return content if isinstance(content, basestring) else ''
 

--- a/transifex/resources/formats/core.py
+++ b/transifex/resources/formats/core.py
@@ -296,7 +296,8 @@ class Handler(object):
         self.suggestions.add(GenericTranslation(*args, **kwargs))
 
     @need_resource
-    def compile(self, language=None, pseudo=None, mode=Mode.DEFAULT):
+    def compile(self, language=None, pseudo=None, mode=Mode.DEFAULT,
+            profile=None):
         """Compile the translation for the specified language.
 
         The actual output of the compilation depends on the arguments.
@@ -305,6 +306,8 @@ class Handler(object):
             language: The language of the translation.
             pseudo: The pseudo type to use (if any).
             mode: The mode of the translation.
+            profile: Optional output profile for format-specific
+                normalization.
         Returns:
             The compiled template in the correct encoding.
         """
@@ -312,6 +315,7 @@ class Handler(object):
             language = self.language
         content = self._content_from_template(self.resource)
         compiler = self.construct_compiler(language, pseudo, mode)
+        compiler.profile = profile
         try:
             return compiler.compile(
                 content, language

--- a/transifex/resources/formats/pofile.py
+++ b/transifex/resources/formats/pofile.py
@@ -349,6 +349,23 @@ class GettextHandler(SimpleCompilerFactory, Handler):
 class GettextCompiler(PluralCompiler):
     """Base compiler for gettext files."""
 
+    ERP_STABLE_PROFILE = 'erp_stable'
+    ERP_STABLE_METADATA = [
+        'Language',
+        'Content-Type',
+        'Content-Transfer-Encoding',
+        'Plural-Forms',
+    ]
+    ERP_VOLATILE_METADATA = [
+        'Project-Id-Version',
+        'Report-Msgid-Bugs-To',
+        'POT-Creation-Date',
+        'PO-Revision-Date',
+        'Last-Translator',
+        'Language-Team',
+        'MIME-Version',
+    ]
+
     def _pre_compile(self, content):
         super(GettextCompiler, self)._pre_compile(content)
         self.po = polib.pofile(content)
@@ -428,6 +445,53 @@ class GettextCompiler(PluralCompiler):
             entry.msgstr_plural = plural_keys
         return unicode(self.po)
 
+    def _is_erp_stable_profile(self):
+        return getattr(self, 'profile', None) == self.ERP_STABLE_PROFILE
+
+    def _post_compile(self, content=None):
+        if self._is_erp_stable_profile():
+            self._apply_erp_stable_profile()
+
+    def _sorted_multiline(self, value):
+        if not value:
+            return value
+        lines = [line for line in value.splitlines() if line]
+        lines.sort()
+        return '\n'.join(lines)
+
+    def _stable_entry_key(self, entry):
+        return (
+            entry.msgid or '',
+            entry.msgctxt or '',
+            entry.msgid_plural or '',
+        )
+
+    def _apply_erp_stable_profile(self):
+        po = polib.pofile(self.compiled_template)
+        po.encoding = self.format_encoding
+        po.header = ''
+        po.metadata_is_fuzzy = 0
+
+        stable_metadata = {}
+        for key in self.ERP_STABLE_METADATA:
+            if key in po.metadata:
+                stable_metadata[key] = po.metadata[key]
+        for key in self.ERP_VOLATILE_METADATA:
+            if key in po.metadata:
+                del po.metadata[key]
+        po.metadata.clear()
+        for key in self.ERP_STABLE_METADATA:
+            if key in stable_metadata:
+                po.metadata[key] = stable_metadata[key]
+
+        po[:] = sorted(po, key=self._stable_entry_key)
+        for entry in po:
+            entry.occurrences = sorted(entry.occurrences)
+            entry.flags = sorted(entry.flags)
+            entry.comment = self._sorted_multiline(entry.comment)
+            entry.tcomment = self._sorted_multiline(entry.tcomment)
+        self.compiled_template = unicode(po)
+
 
 class PoCompiler(GettextCompiler):
     """Compiler for PO files."""
@@ -439,6 +503,8 @@ class PoCompiler(GettextCompiler):
         them with the rest of the text.
         """
         super(PoCompiler, self)._post_compile()
+        if self._is_erp_stable_profile():
+            return
         from transifex.addons.copyright.models import Copyright
         c = Copyright.objects.filter(
             resource=self.resource, language=self.language

--- a/transifex/resources/tests/lib/pofile/main.py
+++ b/transifex/resources/tests/lib/pofile/main.py
@@ -246,6 +246,22 @@ class TestPoFile(FormatsBaseTestCase):
         for entry in po:
             self.assertEqual(entry.occurrences, sorted(entry.occurrences))
 
+    def test_project_compilation_profile_is_used_by_backend(self):
+        self._test_po_save2db()
+        self.resource.project.compilation_profile = 'erp_stable'
+        self.resource.project.save()
+
+        backend = FormatsBackend(
+            self.resource, Language.objects.get(code='en_US')
+        )
+        compiled_template = backend.compile_translation()
+
+        self.assertFalse('PO-Revision-Date' in compiled_template)
+        self.assertFalse('Last-Translator' in compiled_template)
+        po = polib.pofile(compiled_template)
+        msgids = [entry.msgid for entry in po]
+        self.assertEqual(msgids, sorted(msgids))
+
     def test_po_save_and_compile(self):
         handler = self._test_po_save2db()
         self._test_po_compile(handler)

--- a/transifex/resources/tests/lib/pofile/main.py
+++ b/transifex/resources/tests/lib/pofile/main.py
@@ -223,6 +223,29 @@ class TestPoFile(FormatsBaseTestCase):
         self.assertEqual(compiled_template,
                 expected_compiled_template)
 
+    def test_po_compile_erp_stable_profile(self):
+        handler = self._test_po_save2db()
+        handler.bind_resource(self.resource)
+        handler.set_language(Language.objects.get(code='en_US'))
+
+        compiled_template = handler.compile(profile='erp_stable')
+        compiled_template_again = handler.compile(profile='erp_stable')
+
+        self.assertEqual(compiled_template, compiled_template_again)
+        self.assertFalse('PO-Revision-Date' in compiled_template)
+        self.assertFalse('Last-Translator' in compiled_template)
+        self.assertFalse('Project-Id-Version' in compiled_template)
+        self.assertFalse('Report-Msgid-Bugs-To' in compiled_template)
+        self.assertFalse('Language-Team' in compiled_template)
+        self.assertFalse('FIRST AUTHOR' in compiled_template)
+
+        po = polib.pofile(compiled_template)
+        msgids = [entry.msgid for entry in po]
+        self.assertEqual(msgids, sorted(msgids))
+        self.assertEqual(msgids[0], 'Action')
+        for entry in po:
+            self.assertEqual(entry.occurrences, sorted(entry.occurrences))
+
     def test_po_save_and_compile(self):
         handler = self._test_po_save2db()
         self._test_po_compile(handler)

--- a/transifex/resources/views.py
+++ b/transifex/resources/views.py
@@ -430,6 +430,7 @@ def get_translation_file(request, project_slug, resource_slug, lang_code,
 
     try:
         fb = FormatsBackend(resource, language)
+        kwargs['profile'] = request.GET.get('profile')
         template = fb.compile_translation(**kwargs)
     except Exception, e:
         messages.error(request, "Error compiling translation file.")
@@ -470,7 +471,9 @@ def get_pot_file(request, project_slug, resource_slug):
     )
     try:
         fb = FormatsBackend(resource, None)
-        template = fb.compile_translation()
+        template = fb.compile_translation(
+            profile=request.GET.get('profile')
+        )
     except Exception, e:
         messages.error(request, _("Error compiling the pot file."))
         logger.error(

--- a/transifex/templates/projects/project_form.html
+++ b/transifex/templates/projects/project_form.html
@@ -77,7 +77,7 @@
 				<span id="display-advform">{% trans "View advanced fields" %}</span>
 			</div>
       <fieldset id="project-edit-advanced" style="display:none;">
-        {% get_fieldset homepage,trans_instructions,feed,bug_tracker,long_description,webhook,auto_translate_select_service,auto_translate_api_key,logo as advanced_fields from project_form %}
+        {% get_fieldset homepage,trans_instructions,feed,bug_tracker,long_description,compilation_profile,webhook,auto_translate_select_service,auto_translate_api_key,logo as advanced_fields from project_form %}
         {% for field in advanced_fields %}
           <div class="tx-form-field">
             {{ field.label_tag }}{% if field.field.required %}<span class="required">*</span>{% endif %}
@@ -99,4 +99,3 @@
 </div>
 
 {% endblock %}
-


### PR DESCRIPTION
## Summary

- Adds an opt-in `profile=erp_stable` compilation profile for PO/POT downloads.
- Keeps legacy output untouched by default.
- In the ERP-stable profile, removes volatile gettext metadata, clears generated header comments, sorts entries by `msgid`, and sorts references/comments/flags inside each entry.
- Propagates `profile` through classic download views and the resource API.
- Adds a project-level `compilation_profile` setting in the project edit form, backed by a nullable South migration, so a project can default to ERP-stable output without changing client URLs.

## Traceability

- TASK-91131
- Fixes #7

## Validation

- `python2 -m py_compile` on touched Python files: OK via `/home/openclaw/.pyenv/versions/erp2/bin/python`.
- `git diff --check`: OK.
- Focused Django test could not run in this workspace because the available Django is incompatible with this legacy app: `ImportError: cannot import name execute_manager`.
