### PR TITLE
Show pending counts in progress bars

### DIFF
--- a/transifex/resources/tests/templates.py
+++ b/transifex/resources/tests/templates.py
@@ -134,7 +134,7 @@ class ResourcesTemplateTests(BaseTestCase):
         resp = self.client['anonymous'].get(self.urls['resource'])
         self.assertContains(resp, self.language_ar.name, status_code=200,
             msg_prefix="Do not show 0% languages if there is no respective team.")
-        self.assertNotContains(resp, '<div class="stats_string_resource"> 0% </div>')
+        self.assertNotContains(resp, '0% &middot; 0 remaining')
 
         # Test with a new team.
         t = Team.objects.create(language=self.language_ar, project=self.project,
@@ -143,4 +143,18 @@ class ResourcesTemplateTests(BaseTestCase):
         self.assertContains(resp, self.language_ar.name, status_code=200,
             msg_prefix="Show a 0% language if there is a respective team.")
         self.assertContains(resp, '<div class="stats_string_resource">\n'
-            '    0%\n  </div>')
+            '    0% &middot; 0 remaining\n  </div>')
+
+    def test_resource_details_stats_show_remaining_count(self):
+        """Progress labels should expose both percentage and pending strings."""
+        resp = self.client['anonymous'].get(self.urls['resource'])
+        self.assertTemplateUsed(resp, 'resources/resource_detail.html')
+        self.assertContains(resp, '&middot;')
+        self.assertContains(resp, 'remaining')
+
+    def test_resource_actions_stats_show_remaining_count(self):
+        """Resource action progress labels should not rely only on tooltips."""
+        resp = self.client['maintainer'].get(self.urls['resource_actions'])
+        self.assertTemplateUsed(resp, 'resources/resource_actions.html')
+        self.assertContains(resp, '&middot;')
+        self.assertContains(resp, 'remaining')

--- a/transifex/static/css/stats.css
+++ b/transifex/static/css/stats.css
@@ -223,7 +223,7 @@ div.graph_resource {
   margin: 0px;
   padding: 0px;
   margin-right: 1px; /* Due to the right border of div.untranslated_comp */
-  background-color: #eee;
+  background-color: #f0ad4e;
   -moz-box-shadow:    inset 1px 1px 5px #ddd;
   -webkit-box-shadow: inset 1px 1px 5px #ddd;
   box-shadow:         inset 1px 1px 5px #ddd;
@@ -237,9 +237,10 @@ div.stats_string_resource{
   z-index: 2;
   padding-left: 0.8em; 
   font-size: 0.923em;
-  color: #69916a;
+  color: #555;
   height: 12px;
   line-height: 12px;
+  white-space: nowrap;
 }
 
 div.graph_resource_actions {
@@ -248,7 +249,7 @@ div.graph_resource_actions {
   height: 26px;
   margin: 0px;
   padding: 0px;
-  background-color: #eee;
+  background-color: #f0ad4e;
   margin-right: 1px; /* Due to the right border of div.untranslated_comp */
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
@@ -263,10 +264,26 @@ div.stats_string_resource_actions{
   z-index: 2;
   padding-left: 0.8em; 
   font-size: 140%;
-  color: #69916a;
+  color: #555;
   height: 22px;
   line-height: 22px;
 	padding-top: 3px;
+  white-space: nowrap;
+}
+
+div.progress-empty div.graph_resource,
+div.progress-empty div.graph_resource_actions {
+  background-color: #d9534f;
+}
+
+div.progress-complete div.graph_resource,
+div.progress-complete div.graph_resource_actions {
+  background-color: #80b66a;
+}
+
+div.progress-complete div.stats_string_resource,
+div.progress-complete div.stats_string_resource_actions {
+  color: #4f7f42;
 }
 
 div.team-statbar{margin-bottom: 1em;}

--- a/transifex/templates/resources/resource_actions.html
+++ b/transifex/templates/resources/resource_actions.html
@@ -130,9 +130,9 @@
 
     <div class="stats_wrapper">
       {% with 390 as barwidth %}
-      <div class="stats tipsy_enable" style='width:{{ barwidth|add:"60" }}px;' title="{% trans "Translated: " %}{{ stats.translated }}<br/>{% trans "Remaining: " %}{{ stats.untranslated }}{% if show_reviewed_stats %}<br/>{% trans "Reviewed: " %}{{ stats.reviewed }}{% endif %}">
+      <div class="stats tipsy_enable {% ifequal stats.translated stats.total %}progress-complete{% else %}{% ifequal stats.translated 0 %}progress-empty{% else %}progress-partial{% endifequal %}{% endifequal %}" style='width:{{ barwidth|add:"170" }}px;' title="{% trans "Translated: " %}{{ stats.translated }}<br/>{% trans "Remaining: " %}{{ stats.untranslated }}{% if show_reviewed_stats %}<br/>{% trans "Reviewed: " %}{{ stats.reviewed }}{% endif %}">
           <div class="stats_string_resource_actions">
-              {{ stats.translated|percentage:stats.total }}
+              {% blocktrans with stats.translated|percentage:stats.total as percent and stats.untranslated|intcomma as pending %}{{ percent }} &middot; {{ pending }} remaining{% endblocktrans %}
           </div>
           {% stats_bar_actions stats barwidth %}
       </div>

--- a/transifex/templates/resources/stats_bar_simple.html
+++ b/transifex/templates/resources/stats_bar_simple.html
@@ -1,9 +1,10 @@
 {% load i18n %}
+{% load humanize %}
 {% load statistics_resources %}
 
-<div class="stats tipsy_enable" style='width:{{ width|add:"40" }}px;' title="{% trans "Translated: " %}{{ trans }}<br />{% trans "Untranslated: " %}{{ untrans }}{% if show_reviewed_stats %}<br />{% trans "Reviewed: " %}{{ reviewed }}{% endif %}">
+<div class="stats tipsy_enable {% ifequal trans_percent 100 %}progress-complete{% else %}{% ifequal trans_percent 0 %}progress-empty{% else %}progress-partial{% endifequal %}{% endifequal %}" style='width:{{ width|add:"140" }}px;' title="{% trans "Translated: " %}{{ trans }}<br />{% trans "Untranslated: " %}{{ untrans }}{% if show_reviewed_stats %}<br />{% trans "Reviewed: " %}{{ reviewed }}{% endif %}">
   <div class="stats_string_resource">
-    {{ trans_percent }}%
+    {% blocktrans with trans_percent as percent and untrans|intcomma as pending %}{{ percent }}% &middot; {{ pending }} remaining{% endblocktrans %}
   </div>
 
   <div class="graph_resource" style="width: {{width}}px">


### PR DESCRIPTION
## Summary

- show translated percentage plus remaining string count directly in resource progress labels
- add empty/partial/complete CSS states so bars are readable without relying only on tooltip/color sprites
- cover resource detail and resource action templates with assertions for the visible remaining label

## Validation

- `python -m py_compile transifex/resources/tests/templates.py` with Python 2.7
- `git diff --check`
- compiled `resources/stats_bar_simple.html` and `resources/resource_actions.html` with Django 1.3.1 using temporary stubs for unrelated legacy tag libraries

The direct Django test command could not run in the available local env because the active Python 2 environment has Django 1.11.29, while this project requires Django 1.3.1 and `manage.py` imports `execute_manager`.

Fixes #10
Related: TASK-91188
